### PR TITLE
Fix installer SyntaxWarning for invalid regex escape sequences on Python 3.12+

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -1136,7 +1136,7 @@ def _patch_comfy_env_distinfo_normalize(comfyui_path: Path):
     
     # We use a raw string for the regex backslashes, but f-string needed for anchor/marker.
     # To keep it simple, we use a normal string and .replace() instead of f-string
-    _raw_patch = """ANCHOR
+    _raw_patch = r"""ANCHOR
 MARKER
 try:
     _orig_subprocess_run = subprocess.run


### PR DESCRIPTION
### Summary
Fixes an issue where running `installer.py` on Python 3.12 or newer throws a `SyntaxWarning` due to invalid escape sequences (`\-` and `\.`) in a multiline string.

### Details
The developer comments immediately above the patched code correctly suggest using a raw string, but a standard (unicode) string was used instead. This causes Python to incorrectly interpret the regex backslashes as escape characters, leading to syntax warning.

- **The Issue:** A regular multiline string (`"""..."""`) processes backslashes as escape characters. The backslashes before the hyphen (`\-`) and dot (`\.`) within the regex patch are not valid escape sequences in standard Python strings.
- **The Fix:** Changed the string to a **raw string** (`r"""..."""`), aligning it with the original intent. Raw strings treat backslashes as literal characters, safely preventing Python from trying to parse them as escapes.
- **Testing:** Confirmed that the warning does not occur on Python 3.11, but is thrown on newer versions like Python 3.12 and 3.14. It is highly common for users to run the installer using their system Python (e.g., Arch Linux already uses 3.14), so they will encounter this immediately.
- **Future Impact:** As per the [Python 3.12 Release Notes](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes), invalid escape sequences have been upgraded from a `DeprecationWarning` to a `SyntaxWarning`, and will eventually raise a hard `SyntaxError` in a future Python version. Fixing this now prevents the installer from breaking completely.

It doesn't creates a great first impression if the very first thing users see when running the installer is a warning:
```text
./StableGen/installer.py:1151: SyntaxWarning: "\-" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\-"? A raw string is also an option.
  _m = _re_patch.match(r"^([a-zA-Z0-9_\-]+?)-([0-9].*)\.dist-info$", _p.name)
Please enter the full path to your ComfyUI installation directory:
```

Note: This problem is present in the latest release (`v0.3.1`) as well as the current `main` branch.